### PR TITLE
SyntaxError: Identifier 'head' has already been declared

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const express = require('express')
 const fs = require('fs')
 const path = require('path')
@@ -24,7 +26,7 @@ app.get('/video', function(req, res) {
 
     const chunksize = (end-start)+1
     const file = fs.createReadStream(path, {start, end})
-    const head = {
+    let head = {
       'Content-Range': `bytes ${start}-${end}/${fileSize}`,
       'Accept-Ranges': 'bytes',
       'Content-Length': chunksize,
@@ -34,7 +36,7 @@ app.get('/video', function(req, res) {
     res.writeHead(206, head)
     file.pipe(res)
   } else {
-    const head = {
+    let head = {
       'Content-Length': fileSize,
       'Content-Type': 'video/mp4',
     }


### PR DESCRIPTION
```sh
SyntaxError: Identifier 'head' has already been declared
    at /home/anyms/Desktop/video-stream-sample/server.js:12:27
    at Layer.handle [as handle_request] (/home/anyms/Desktop/video-stream-sample/node_modules/express/lib/router/layer.js:95:5)
    at next (/home/anyms/Desktop/video-stream-sample/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/home/anyms/Desktop/video-stream-sample/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/home/anyms/Desktop/video-stream-sample/node_modules/express/lib/router/layer.js:95:5)
    at /home/anyms/Desktop/video-stream-sample/node_modules/express/lib/router/index.js:281:22
    at Function.process_params (/home/anyms/Desktop/video-stream-sample/node_modules/express/lib/router/index.js:335:12)
    at next (/home/anyms/Desktop/video-stream-sample/node_modules/express/lib/router/index.js:275:10)
    at SendStream.error (/home/anyms/Desktop/video-stream-sample/node_modules/serve-static/index.js:121:7)
    at emitOne (events.js:77:13)
```

head variable added to global scope, I just changed it to local scope using `let`